### PR TITLE
use git tag for versioning, reduce chance of inconsistency from  manual modification of .app.src file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+*.*~
+*~
+*.dump
 .eunit
 deps/
 ebin/

--- a/rebar.config
+++ b/rebar.config
@@ -9,10 +9,13 @@
     %% Uncomment the follow line and re-run make to install the dependency.
     %% See https://github.com/basho/erlang_js for more information.
     %%     {erlang_js, ".*", {git, "https://github.com/basho/erlang_js.git", {tag, "1.2.2"}}},
-    {lager, ".*", {git, "https://github.com/basho/lager.git", {tag, "2.0.0rc2"}}},
+    {lager, "", {git, "https://github.com/basho/lager.git", {tag, "2.0.1"}}},
     {folsom, ".*", {git, "https://github.com/boundary/folsom.git", {tag, "0.7.4"}}},
     {cowboy, ".*", {git, "https://github.com/extend/cowboy.git", {tag, "0.8.6"}}},
-    {mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.7.0"}}}
+    {mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.7.0"}}},
+    {rebar_vsn_plugin, "",
+     {git, "https://github.com/erlware/rebar_vsn_plugin.git",
+      {tag, "v0.0.4"}}}
 ]}.
 
 

--- a/rebar.config
+++ b/rebar.config
@@ -14,9 +14,13 @@
     {cowboy, ".*", {git, "https://github.com/extend/cowboy.git", {tag, "0.8.6"}}},
     {mochiweb, ".*", {git, "https://github.com/mochi/mochiweb.git", {tag, "v2.7.0"}}},
     {rebar_vsn_plugin, "",
-     {git, "https://github.com/erlware/rebar_vsn_plugin.git",
+      {git, "https://github.com/erlware/rebar_vsn_plugin.git",
       {tag, "v0.0.4"}}}
+
 ]}.
+
+{plugins, [rebar_vsn_plugin]}.
+{plugin_dir, "deps/rebar_vsn_plugin/src"}.
 
 
 

--- a/src/habanero.app.src
+++ b/src/habanero.app.src
@@ -2,7 +2,7 @@
 {application, habanero,
     [
         {description, "A light weight loadtesting framework."},
-        {vsn, git},
+        {vsn, "semver"},
         {registered, []},
         {applications, [
             kernel,

--- a/src/habanero.app.src
+++ b/src/habanero.app.src
@@ -2,7 +2,7 @@
 {application, habanero,
     [
         {description, "A light weight loadtesting framework."},
-        {vsn, "1.0.0"},
+        {vsn, git},
         {registered, []},
         {applications, [
             kernel,


### PR DESCRIPTION
Current versions of repo is from modification in vsn in app.src. This is error prone for release.
There is a plugin from erlware where you can use git tag to do that. This is NOT the git sha that we commonly encounter. 

(more information :https://github.com/erlware/rebar_vsn_plugin)
They have 2 styles: git version style (tag plus commit sha hash)
And sematic version style (just that tag)

Here are the proposed changes (please see file changes):
- include https://github.com/erlware/rebar_vsn_plugin.git in rebar.config
- in ap.src file vsn is git or "semver" rather than hand coded "1.0.0". The two styles are descriped rebar_vsn_plugin github link listed above.
  The downside is that, you need to create the git  tag in proper format (see link) from where rebar_vsn_plugin will gets the value and stuff that in on compile.
